### PR TITLE
[#19] Rename Error to FormError

### DIFF
--- a/components/CreateReactionForm.tsx
+++ b/components/CreateReactionForm.tsx
@@ -1,13 +1,13 @@
 /* eslint-disable react/display-name */
 import { FormEvent, memo, useCallback, useState } from "react";
 import { ReactionForm, ReactionPayload } from "../lib/reaction";
-import { Error } from "../lib/shared";
+import { FormError } from "../lib/shared";
 
 export const CreateReactionForm = memo<{ offerId: string }>(({ offerId }) => {
 	const [submitting, setSubmitting] = useState<
 		false | "loading" | "error" | "success"
 	>(false);
-	const [errors, setErrors] = useState<Error[]>([]);
+	const [errors, setErrors] = useState<FormError[]>([]);
 	const [state, setState] = useState<ReactionForm>({
 		email: "",
 		phone: "+420",

--- a/components/EditForm.tsx
+++ b/components/EditForm.tsx
@@ -6,7 +6,7 @@ import {
 	QuestionValue,
 	PublicQueryResult,
 	RegisterFormState,
-	Error,
+	FormError,
 } from "../lib/shared";
 import { QuestionControl } from "./QuestionControl";
 import { default as Select } from "react-select";
@@ -34,7 +34,7 @@ export const EditForm = memo<RegisterFormProps>(
 		const [submitting, setSubmitting] = useState<
 			false | "loading" | "error" | "success"
 		>(false);
-		const [errors, setErrors] = useState<Error[]>([]);
+		const [errors, setErrors] = useState<FormError[]>([]);
 		const [state, setState] = useState(questions);
 		const [statusState, setStatusState] = useState(offerStatusType);
 

--- a/components/HelpForm.tsx
+++ b/components/HelpForm.tsx
@@ -6,8 +6,6 @@ import {
 	QuestionDefinition,
 	QuestionValue,
 	PublicQueryResult,
-	RegisterFormState,
-	Error,
 	HelpFormState,
 	ErrorMultilingual,
 } from "../lib/shared";

--- a/components/RegisterForm.tsx
+++ b/components/RegisterForm.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/display-name */
 import { FormEvent, memo, useCallback, useState } from "react";
-import { Error, PublicQueryResult, RegisterFormState } from "../lib/shared";
+import { FormError, PublicQueryResult, RegisterFormState } from "../lib/shared";
 import { QuestionControl } from "./QuestionControl";
 
 const Required = () => {
@@ -12,7 +12,7 @@ export const RegisterForm = memo<PublicQueryResult>(
 		const [submitting, setSubmitting] = useState<
 			false | "loading" | "error" | "success"
 		>(false);
-		const [errors, setErrors] = useState<Error[]>([]);
+		const [errors, setErrors] = useState<FormError[]>([]);
 		const [state, setState] = useState<RegisterFormState>({
 			name: "",
 			email: "",

--- a/lib/shared.ts
+++ b/lib/shared.ts
@@ -88,8 +88,7 @@ export interface HelpFormState {
 	types: string[];
 }
 
-//FIXME https://github.com/cesko-digital/pomahejukrajine-web/issues/19
-export type Error =
+export type FormError =
 	| { input: "question"; questionId: string; message: string }
 	| { input: "email"; message: string }
 	| { input: "offer"; message: string }

--- a/lib/validateOffer.ts
+++ b/lib/validateOffer.ts
@@ -1,10 +1,10 @@
-import { Error, OfferType, QuestionValue } from "./shared";
+import { FormError, OfferType, QuestionValue } from "./shared";
 
 export function validateOffer(
 	offerType: OfferType,
 	parameters: { [p: string]: QuestionValue }
-): Error[] {
-	const errors: Error[] = [];
+): FormError[] {
+	const errors: FormError[] = [];
 
 	for (const question of offerType.questions) {
 		const value = parameters[question.id];

--- a/pages/api/create-reaction.ts
+++ b/pages/api/create-reaction.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { Error } from "../../lib/shared";
+import { FormError } from "../../lib/shared";
 import { ReactionPayload } from "../../lib/reaction";
 
 export default async function handler(
@@ -10,7 +10,7 @@ export default async function handler(
 
 	// TODO: Validation
 
-	let errors: Error[] = [];
+	let errors: FormError[] = [];
 
 	if (data.email.match(/^[^@ ]+@[^@ ]+\.[^@ ]+$/) === null) {
 		errors.push({

--- a/pages/api/register.ts
+++ b/pages/api/register.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import generateUniqueCode from "../../lib/generateUniqueCode";
 import {
-	Error,
+	FormError,
 	publicQuery,
 	PublicQueryResult,
 	RegisterFormState,
@@ -32,7 +32,7 @@ export default async function handler(
 
 	const { offerTypes = [] } = (await fetchTypes()) || {};
 
-	const errors: Error[] = [];
+	const errors: FormError[] = [];
 
 	if (data.email.match(/^[^@ ]+@[^@ ]+\.[^@ ]+$/) === null) {
 		errors.push({

--- a/pages/api/updateOffer.ts
+++ b/pages/api/updateOffer.ts
@@ -1,7 +1,7 @@
 import Cookies from "cookies";
 import type { NextApiRequest, NextApiResponse } from "next";
 import {
-	Error,
+	FormError,
 	OfferParameters,
 	publicQuery,
 	PublicQueryResult,
@@ -62,7 +62,7 @@ export default async function handler(
 			? offerTypes.find((type) => type.id === offerTypeId)
 			: undefined;
 
-	const errors: Error[] = [];
+	const errors: FormError[] = [];
 
 	if (!offerType) {
 		throw new Error(`Offer type ${offerTypeId} not found`);


### PR DESCRIPTION
fixes #19 

Since Error is a type already existing in JS, this causes confusion and inability to use Error in a file where the FormError is required. 