### PR TITLE
Chore: Move styles to css module files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"css.lint.unknownAtRules": "ignore"
+}

--- a/components/OfferFilter.module.css
+++ b/components/OfferFilter.module.css
@@ -1,0 +1,20 @@
+.defaultButton {
+	@apply text-gray-900
+    font-medium
+    py-2
+    px-4
+    border
+    rounded-3xl
+    m-1
+    bg-white
+    border-gray-200
+    hover:bg-blue-50;
+}
+
+.activeButton {
+	@apply bg-blue-600
+    text-white
+    border-blue-800
+    shadow-sm
+    hover:bg-blue-600;
+}

--- a/components/OfferFilter.tsx
+++ b/components/OfferFilter.tsx
@@ -1,13 +1,7 @@
 import { OfferType } from "../lib/shared";
 import cx from "classnames";
 import { useCallback } from "react";
-
-const styles = {
-	defaultButton:
-		"text-gray-900 font-medium py-2 px-4 border rounded-3xl m-1 text-md bg-white border-gray-200 hover:bg-blue-50",
-	activeButton:
-		"bg-blue-600 text-white border-blue-800 shadow-sm hover:bg-blue-600",
-};
+import styles from "./OfferFilter.module.css";
 
 const Filter: React.FC<{
 	availableTypes: { [name: string]: number };

--- a/components/OfferSubFilter.module.css
+++ b/components/OfferSubFilter.module.css
@@ -1,0 +1,20 @@
+.defaultButton {
+	@apply text-gray-900
+    font-medium
+    py-1
+    px-2
+    border
+    rounded-3xl
+    m-1
+    text-sm
+    bg-white
+    border-gray-200
+    hover:bg-blue-50;
+}
+.activeButton {
+	@apply bg-blue-600
+    text-white
+    border-blue-800
+    shadow-sm
+    hover:bg-blue-600;
+}

--- a/components/OfferSubFilter.tsx
+++ b/components/OfferSubFilter.tsx
@@ -1,12 +1,6 @@
 import { FilterWithCount, QuestionFilter } from "../lib/model/FilterModel";
 import cx from "classnames";
-
-const styles = {
-	defaultButton:
-		"text-gray-900 font-medium py-1 px-2 border rounded-3xl m-1 text-sm bg-white border-gray-200 hover:bg-blue-50",
-	activeButton:
-		"bg-blue-600 text-white border-blue-800 shadow-sm hover:bg-blue-600",
-};
+import styles from "./OfferSubFilter.module.css";
 
 const OfferSubFilter: React.FC<{
 	shownFilters: Array<FilterWithCount>;

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"postcss": "^8.4.12",
 		"prettier": "^2.6.0",
 		"start-server-and-test": "^1.14.0",
-		"typescript": "4.5.5"
+		"typescript": "4.5.5",
+		"typescript-plugin-css-modules": "^3.4.0"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,12 @@
 		"resolveJsonModule": true,
 		"isolatedModules": true,
 		"jsx": "preserve",
-		"incremental": true
+		"incremental": true,
+		"plugins": [
+			{
+				"name": "typescript-plugin-css-modules"
+			}
+		]
 	},
 	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
 	"exclude": ["node_modules"]


### PR DESCRIPTION
I think this is a better way to do it. It allows for autocompletion, which was a problem in the previous solution.

- Moves reusable styles for buttons to module.css files
- introduces `typescript-plugin-css-modules` so that we can get autocompletion when referencing the styles from components
- sets the version of typescript to be used to the one present in the repo (instead of any version installed with vscode, this can fix some issues across different versions and also allows the use of the aforementioned plugin)