### PR TITLE
Set up dependabot to send batched updates once a week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This patch makes dependabot send batched dependency updates once a week instead of sending a separate PR for every dependency update.